### PR TITLE
Bump org.jetbrains.kotlin.jvm from 1.4.32 to 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
 plugins {
     id "java"
     id "maven-publish"
-    id "org.jetbrains.kotlin.jvm" version "1.4.32"
+    id "org.jetbrains.kotlin.jvm" version "1.5.0"
     id "me.bristermitten.pdm" version "0.0.33"
     id "com.github.johnrengelman.shadow" version "6.1.0"
 }


### PR DESCRIPTION
Bumps org.jetbrains.kotlin.jvm from 1.4.32 to 1.5.0.

Signed-off-by: dependabot[bot] <support@github.com>